### PR TITLE
Use new syntax for defining named tuples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s3-metadata-tagger"
-version = "0.3.1"
+version = "0.3.2"
 description = "A package to add metadata tags to objects saved in s3"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Named tuples can be instantiated just like classes since python 3.6,
which allows for more readable code.
This refactoring is done here.