### PR TITLE
Exclude examples directory from security scan

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,7 +158,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           trivy-config: trivy.yaml
-          skip-dirs: 'examples'
+          skip-dirs: /github/workspace/examples
       - name: Archive trivy results
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -157,7 +157,10 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          trivy-config: trivy.yaml
+          format: template
+          template: '@/contrib/html.tpl'
+          exit-code: 1
+          severity: CRITICAL,HIGH
           skip-dirs: /github/workspace/examples
       - name: Archive trivy results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,6 +136,8 @@ jobs:
           format: 'HTML'    
           args: >
             --failOnCVSS 6
+            --exclude **/examples/**
+            --enableExperimentals
       - name: Upload Test results
         uses: actions/upload-artifact@master
         if: always()
@@ -157,6 +159,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           trivy-config: trivy.yaml
+          skip-dirs: examples
       - name: Archive trivy results
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,7 +137,6 @@ jobs:
           args: >
             --failOnCVSS 6
             --exclude **/examples/**
-            --enableExperimentals
       - name: Upload Test results
         uses: actions/upload-artifact@master
         if: always()
@@ -159,7 +158,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           trivy-config: trivy.yaml
-          skip-dirs: examples
+          skip-dirs: 'examples'
       - name: Archive trivy results
         uses: actions/upload-artifact@v3
         if: always()

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,5 +1,0 @@
-format: template
-template: "@/contrib/html.tpl"
-exit-code: 1
-severity: CRITICAL,HIGH
-output: trivy-results.html


### PR DESCRIPTION
Since we do not really care for security alerts in the example directory, it should be excluded from the trivy and owasp scan